### PR TITLE
Restrict babel-core peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "node-hook": "^0.1.0"
   },
   "peerDependencies": {
-    "babel-core": ">=5.7.0"
+    "babel-core": ">=5.7.0 <6.0.0"
   }
 }


### PR DESCRIPTION
It seems that babel-plugin-rewire is not compatible with the latest babel-core 6.0.0. This peerDependency restriction should save a few headaches.
